### PR TITLE
Fixbranch1

### DIFF
--- a/app/controllers/public/addresses_controller.rb
+++ b/app/controllers/public/addresses_controller.rb
@@ -39,6 +39,6 @@ class Public::AddressesController < ApplicationController
 
   private
   def address_params
-    params.require(:address).permit(:customer_id, :name, :address, :post_code)
+    params.require(:address).permit(:customer_id, :name, :address, :post_code,)
   end
 end

--- a/app/controllers/public/addresses_controller.rb
+++ b/app/controllers/public/addresses_controller.rb
@@ -39,6 +39,6 @@ class Public::AddressesController < ApplicationController
 
   private
   def address_params
-    params.require(:address).permit(:customer_id, :name, :address, :post_code,)
+    params.require(:address).permit(:customer_id, :name, :address, :post_code)
   end
 end

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -13,15 +13,18 @@ class Public::OrdersController < ApplicationController
       @order.post_code = current_customer.post_code
       @order.address = current_customer.address
       @order.name = current_customer.last_name + current_customer.first_name
+      
     elsif params[:order][:select_address] == "1"
-      @address = Address.find(params[:order][:customer_id]) # orderのcustomer_idカラムでアドレス帳id=xを取得
-      @order.post_code = @address.poset_code
+      @address = Address.find(params[:order][:address_id]) # orderのaddress_idカラムでアドレス帳id=xを取得
+      @order.post_code = @address.post_code
       @order.address = @address.address
       @order.name = @address.name
+      
     elsif params[:order][:select_address] == "2"
       @order.post_code = params[:order][:post_code]
       @order.address = params[:order][:address]
       @order.name = params[:order][:name]
+      
     else
       render "new"
     end

--- a/app/controllers/public/registrations_controller.rb
+++ b/app/controllers/public/registrations_controller.rb
@@ -44,7 +44,7 @@ class Public::RegistrationsController < Devise::RegistrationsController
   def configure_sign_up_params
     devise_parameter_sanitizer.permit(:sign_up, keys: [:last_name, :first_name, :last_name_kana, :first_name_kana, :post_code, :address, :telephone_number, :email])
   end
-  
+
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_account_update_params
   #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])


### PR DESCRIPTION
Error Fix

注文時、住所を既存の住所から選択→エラー

addressの取得にorderのcustomer_idで取得しようとしていた。
address_idに訂正。

あとpost_codeのタイポ。